### PR TITLE
Update Dependencies.cmake

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -219,12 +219,7 @@ endif()
 
 # ---[ EIGEN
 set(EIGEN_MPL2_ONLY 1)
-find_package(Eigen3 QUIET)
-if(EIGEN3_FOUND)
-  caffe2_include_directories(${EIGEN3_INCLUDE_DIRS})
-else()
-  caffe2_include_directories(${PROJECT_SOURCE_DIR}/third_party/eigen)
-endif()
+caffe2_include_directories(${PROJECT_SOURCE_DIR}/third_party/eigen)
 
 # ---[ Python + Numpy
 if(BUILD_PYTHON)


### PR DESCRIPTION
The original one was trying to find Eigen in /usr/include/eigen3 and it is different from the Eigen provided in the thirdparty folder. I am using Eigen versoin 1.12 and 1.13 and somehow neither of them is the same as the provided one.